### PR TITLE
fix(order-form): parameter typo in menuItemChosen() resolves #14

### DIFF
--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -20,7 +20,7 @@ class OrderForm extends Component {
     }
 
     menuItemChosen(event) {
-        this.setState({ item: event.target.value });
+        this.setState({ order_item: event.target.value });
     }
 
     menuQuantityChosen(event) {


### PR DESCRIPTION
Resolves Issue #14 Intentional Bug: Order form submit doesn't work

There was a type in the parameters inside the menuItemChosen() function that prevented orders from being submitted. I correct the typo '{item: event.target.value}' to '{order_item: event.target.value}'